### PR TITLE
Update Elixir parent to 1.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.6-alpine
+FROM elixir:1.7-alpine
 
 ENV UID=911 GID=911 \
     MIX_ENV=prod


### PR DESCRIPTION
As of [recently](https://git.pleroma.social/pleroma/pleroma/commit/58b12c09db96da4f3aafac60fc7e17517814a401) Pleroma requires Elixir 1.7.