### PR TITLE
Remove unnecessary mkdir command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN mix local.rebar --force \
     && mix deps.get \
     && mix compile
 
-RUN mkdir /pleroma/uploads
 VOLUME /pleroma/uploads/
 
 CMD ["mix", "phx.server"]


### PR DESCRIPTION
The current version of the Dockerfile errors out with `mkdir: can't create directory '/pleroma/uploads': File exists`. Removing it seemingly fixed the problem and the image builds fine.