### PR TITLE
config option to bind pleroma webendpoint on all interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Configure Pleroma. Copy the following to `config/secret.exs`:
 use Mix.Config
 
 config :pleroma, Pleroma.Web.Endpoint,
+   http: [ ip: {0, 0, 0, 0}, ],
    url: [host: "pleroma.domain.tld", scheme: "https", port: 443],
    secret_key_base: "<use 'openssl rand -base64 48' to generate a key>"
 


### PR DESCRIPTION
Hi,

i dunno if it helps or if you want it in your readme, but pleroma recently changed their default ip binding -> https://git.pleroma.social/pleroma/pleroma/issues/614

so i had overwrite their changes and bind pleroma back on 0.0.0.0 cause without that my pleroma wouldn't be reachable through the nginx proxy on the host maschine (i think it still works within the same docker network, via docker-compose etc)