### PR TITLE
Fix permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,6 @@ RUN mix local.rebar --force \
 
 VOLUME /pleroma/uploads/
 
+RUN chown -R pleroma:pleroma ./
+
 CMD ["mix", "phx.server"]


### PR DESCRIPTION
So it's seems that this docker doesn't set any permissions for pleroma user and because of that when you use dashboard, it's broken and screams with errors. The PR fixes this.