### PR TITLE
Fix and explain user buildargs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 FROM elixir:1.11.4-alpine
 
-ENV UID=911 GID=911 \
-    MIX_ENV=prod
-
 ARG PLEROMA_VER=develop
+ARG UID=911
+ARG GID=911
 ENV UID=911 GID=911 MIX_ENV=prod
-
-ENV MIX_ENV=prod
 
 RUN echo "http://nl.alpinelinux.org/alpine/latest-stable/community" >> /etc/apk/repositories \
     && apk update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM elixir:1.11.4-alpine
 ARG PLEROMA_VER=develop
 ARG UID=911
 ARG GID=911
-ENV UID=911 GID=911 MIX_ENV=prod
+ENV MIX_ENV=prod
 
 RUN echo "http://nl.alpinelinux.org/alpine/latest-stable/community" >> /etc/apk/repositories \
     && apk update \

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ docker-compose build
 docker build -t pleroma .
 ```
 
-I prefer the latter because it's more verbose.
+I prefer the latter because it's more verbose but this will ignore any build-time variables you have set in `docker-compose.yml`.
 
 Setup the database:
 

--- a/README.md
+++ b/README.md
@@ -49,12 +49,19 @@ services:
       - ./postgres:/var/lib/postgresql/data
 
   web:
-    build: .
     image: pleroma
     container_name: pleroma_web
     restart: always
     ports:
       - '4000:4000'
+    build:
+      context: .
+      # Feel free to remove or override this section
+      # See 'Build-time variables' in README.md
+      args:
+        - "UID=911"
+        - "GID=911"
+        - "PLEROMA_VER=develop"
     volumes:
       - ./uploads:/var/lib/pleroma/uploads
       - ./static:/var/lib/pleroma/static
@@ -199,6 +206,8 @@ docker build -t pleroma . --build-arg PLEROMA_VER=v2.0.7 # a version
 ```
 
 `a9203ab3` being the hash of the commit. (They're [here](https://git.pleroma.social/pleroma/pleroma/commits/develop))
+
+This value can also be set through `docker-compose.yml` as seen in the example file provided in this repository.
 
 ## Other Docker images
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,9 @@ services:
       # Feel free to remove or override this section
       # See 'Build-time variables' in README.md
       args:
-        - "UID=911"
-        - "GID=911"
-        - "PLEROMA_VER=develop"
+        - "UID=1000"
+        - "GID=1000"
+        - "PLEROMA_VER=v2.4.2"
     volumes:
       - ./uploads:/var/lib/pleroma/uploads
       - ./static:/var/lib/pleroma/static

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,19 @@ services:
       - ./postgres:/var/lib/postgresql/data
 
   web:
-    build: .
     image: pleroma
     container_name: pleroma_web
     restart: always
     ports:
       - '4000:4000'
+    build:
+      context: .
+      # Feel free to remove or override this section
+      # See 'Build-time variables' in README.md
+      args:
+        - "UID=911"
+        - "GID=911"
+        - "PLEROMA_VER=develop"
     volumes:
       - ./uploads:/var/lib/pleroma/uploads
       - ./static:/var/lib/pleroma/static


### PR DESCRIPTION
When trying to build the image with another uid/gid for the Pleroma user I stumbled into some problems, so:

- Fixed some duplicate and conflicting arg/env entries in the dockerfile
- Added info on how to use build args in the docker-compose file