### PR TITLE
Fix typo in config-override.exs

### DIFF
--- a/config-override.exs
+++ b/config-override.exs
@@ -1,4 +1,4 @@
-import config
+import Config
 
 config :pleroma, :instance,
   registrations_open: false


### PR DESCRIPTION
It needs to import Config, not config.