### PR TITLE
Update config-override.exs

### DIFF
--- a/config-override.exs
+++ b/config-override.exs
@@ -1,4 +1,4 @@
-import config
+import Config
 
 config :pleroma, :instance,
   registrations_open: false


### PR DESCRIPTION
Fix capitalisation of "config"

With lower case "config" get the error `variable "config" does not exist and is being expanded to "config()", please use parentheses to remove the ambiguity or change the variable name`. Capitalising the 'c' removes the error.