### PR TITLE
Install openssl-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ ENV MIX_ENV=prod
 RUN echo "http://nl.alpinelinux.org/alpine/latest-stable/main" >> /etc/apk/repositories \
     && apk update \
     && apk add git gcc g++ musl-dev make cmake file-dev \
-    exiftool imagemagick libmagic ncurses postgresql-client ffmpeg
+    exiftool imagemagick libmagic ncurses postgresql-client ffmpeg \
+    openssl-dev
 
 RUN addgroup -g ${GID} pleroma \
     && adduser -h /pleroma -s /bin/false -D -G pleroma -u ${UID} pleroma


### PR DESCRIPTION
The latest builds were failing for me with this error:

```
55.22 Error relocating /usr/bin/cmake: SSL_get0_group_name: symbol not found
55.22 make: *** [Makefile:49: c_src/lexbor/liblexbor_static.a] Error 127
```

Installing `openssl-dev` makes the build succeed again.